### PR TITLE
fix: ack message subtypes so Slack stops disabling event subscriptions

### DIFF
--- a/library/slackcat/data/chat/src/main/kotlin/com/slackcat/chat/engine/slack/SlackChatEngine.kt
+++ b/library/slackcat/data/chat/src/main/kotlin/com/slackcat/chat/engine/slack/SlackChatEngine.kt
@@ -4,7 +4,27 @@ import com.slack.api.bolt.App
 import com.slack.api.bolt.socket_mode.SocketModeApp
 import com.slack.api.model.Attachment
 import com.slack.api.model.event.MessageBotEvent
+import com.slack.api.model.event.MessageChangedEvent
+import com.slack.api.model.event.MessageChannelArchiveEvent
+import com.slack.api.model.event.MessageChannelConvertToPublicEvent
+import com.slack.api.model.event.MessageChannelJoinEvent
+import com.slack.api.model.event.MessageChannelLeaveEvent
+import com.slack.api.model.event.MessageChannelNameEvent
+import com.slack.api.model.event.MessageChannelPostingPermissionsEvent
+import com.slack.api.model.event.MessageChannelPurposeEvent
+import com.slack.api.model.event.MessageChannelTopicEvent
+import com.slack.api.model.event.MessageChannelUnarchiveEvent
+import com.slack.api.model.event.MessageDeletedEvent
+import com.slack.api.model.event.MessageEkmAccessDeniedEvent
 import com.slack.api.model.event.MessageEvent
+import com.slack.api.model.event.MessageFileShareEvent
+import com.slack.api.model.event.MessageGroupTopicEvent
+import com.slack.api.model.event.MessageMeEvent
+import com.slack.api.model.event.MessageMetadataDeletedEvent
+import com.slack.api.model.event.MessageMetadataPostedEvent
+import com.slack.api.model.event.MessageMetadataUpdatedEvent
+import com.slack.api.model.event.MessageRepliedEvent
+import com.slack.api.model.event.MessageThreadBroadcastEvent
 import com.slack.api.model.event.ReactionAddedEvent
 import com.slack.api.model.event.ReactionRemovedEvent
 import com.slackcat.chat.engine.ChatEngine
@@ -92,6 +112,34 @@ class SlackChatEngine(private val globalCoroutineScope: CoroutineScope) : ChatEn
                 )
             }
             ctx.ack()
+        }
+
+        // Bolt routes message subtypes (channel_join, message_changed, etc.) to dedicated event
+        // classes. Without registered handlers, Bolt returns 404 and Slack retries — repeated
+        // 404s cause Slack to auto-disable Event Subscriptions. Ack the subtypes we don't act on.
+        listOf(
+            MessageChangedEvent::class.java,
+            MessageChannelArchiveEvent::class.java,
+            MessageChannelConvertToPublicEvent::class.java,
+            MessageChannelJoinEvent::class.java,
+            MessageChannelLeaveEvent::class.java,
+            MessageChannelNameEvent::class.java,
+            MessageChannelPostingPermissionsEvent::class.java,
+            MessageChannelPurposeEvent::class.java,
+            MessageChannelTopicEvent::class.java,
+            MessageChannelUnarchiveEvent::class.java,
+            MessageDeletedEvent::class.java,
+            MessageEkmAccessDeniedEvent::class.java,
+            MessageFileShareEvent::class.java,
+            MessageGroupTopicEvent::class.java,
+            MessageMeEvent::class.java,
+            MessageMetadataDeletedEvent::class.java,
+            MessageMetadataPostedEvent::class.java,
+            MessageMetadataUpdatedEvent::class.java,
+            MessageRepliedEvent::class.java,
+            MessageThreadBroadcastEvent::class.java,
+        ).forEach { eventClass ->
+            app.event(eventClass) { _, ctx -> ctx.ack() }
         }
 
         val socketModeApp = SocketModeApp(System.getenv("SLACK_APP_TOKEN"), app)


### PR DESCRIPTION
## Summary
- Bolt routes Slack message subtypes (`channel_join`, `message_changed`, etc.) to dedicated event classes rather than the generic `MessageEvent`. With no handler registered, Bolt returns `404 "no handler found"`, Slack retries (`retry_attempt: 2`, `retry_attempt: 3`), and after enough failures Slack auto-disables the app's Event Subscriptions.
- Register no-op `ctx.ack()` handlers in `SlackChatEngine` for the message subtypes the framework doesn't process so Slack treats deliveries as successful.

## Repro evidence
From a live bot using this framework:
```
WARN -- No BoltEventHandler registered for event: message:channel_join
WARN -- Unsuccessful Bolt app execution (status: 404, body: {"error":"no handler found"})
```
Same envelope re-delivered with `retry_attempt: 2` then `retry_attempt: 3`. After enough of these the Slack app's Event Subscriptions get turned off.

## Test plan
- [x] `:library:slackcat:data:chat:compileKotlin` passes
- [ ] Deploy a build of the framework to a bot and confirm `channel_join` events no longer log a 404 / "no handler found"
- [ ] Confirm Event Subscriptions stay enabled over a longer period (no more auto-disables)

🤖 Generated with [Claude Code](https://claude.com/claude-code)