### PR TITLE
feat: emit MemberJoinedChannel event when users join a channel

### DIFF
--- a/library/slackcat/core/common/src/main/kotlin/com/slackcat/common/SlackcatEvent.kt
+++ b/library/slackcat/core/common/src/main/kotlin/com/slackcat/common/SlackcatEvent.kt
@@ -37,4 +37,9 @@ sealed interface SlackcatEvent {
         val timestamp: String,
         val threadTimestamp: String?,
     ) : SlackcatEvent
+
+    data class MemberJoinedChannel(
+        val userId: String,
+        val channelId: String,
+    ) : SlackcatEvent
 }

--- a/library/slackcat/data/chat/src/main/kotlin/com/slackcat/chat/engine/slack/SlackChatEngine.kt
+++ b/library/slackcat/data/chat/src/main/kotlin/com/slackcat/chat/engine/slack/SlackChatEngine.kt
@@ -3,11 +3,11 @@ package com.slackcat.chat.engine.slack
 import com.slack.api.bolt.App
 import com.slack.api.bolt.socket_mode.SocketModeApp
 import com.slack.api.model.Attachment
+import com.slack.api.model.event.MemberJoinedChannelEvent
 import com.slack.api.model.event.MessageBotEvent
 import com.slack.api.model.event.MessageChangedEvent
 import com.slack.api.model.event.MessageChannelArchiveEvent
 import com.slack.api.model.event.MessageChannelConvertToPublicEvent
-import com.slack.api.model.event.MemberJoinedChannelEvent
 import com.slack.api.model.event.MessageChannelJoinEvent
 import com.slack.api.model.event.MessageChannelLeaveEvent
 import com.slack.api.model.event.MessageChannelNameEvent

--- a/library/slackcat/data/chat/src/main/kotlin/com/slackcat/chat/engine/slack/SlackChatEngine.kt
+++ b/library/slackcat/data/chat/src/main/kotlin/com/slackcat/chat/engine/slack/SlackChatEngine.kt
@@ -7,6 +7,7 @@ import com.slack.api.model.event.MessageBotEvent
 import com.slack.api.model.event.MessageChangedEvent
 import com.slack.api.model.event.MessageChannelArchiveEvent
 import com.slack.api.model.event.MessageChannelConvertToPublicEvent
+import com.slack.api.model.event.MemberJoinedChannelEvent
 import com.slack.api.model.event.MessageChannelJoinEvent
 import com.slack.api.model.event.MessageChannelLeaveEvent
 import com.slack.api.model.event.MessageChannelNameEvent
@@ -109,6 +110,17 @@ class SlackChatEngine(private val globalCoroutineScope: CoroutineScope) : ChatEn
                     messageTimestamp = event.item.ts,
                     itemUserId = event.itemUser,
                     eventTimestamp = event.eventTs,
+                )
+            }
+            ctx.ack()
+        }
+
+        app.event(MemberJoinedChannelEvent::class.java) { payload, ctx ->
+            val event = payload.event
+            emitEvent {
+                SlackcatEvent.MemberJoinedChannel(
+                    userId = event.user,
+                    channelId = event.channel,
                 )
             }
             ctx.ack()


### PR DESCRIPTION
## Summary

- Adds `MemberJoinedChannel(userId: String, channelId: String)` as a new variant to the `SlackcatEvent` sealed interface in `SlackcatEvent.kt`
- Wires up a `MemberJoinedChannelEvent` handler in `SlackChatEngine` that emits `SlackcatEvent.MemberJoinedChannel` onto the shared events flow

Previously, Slack's `member_joined_channel` event was received by the Bolt app but had no registered handler, so it was silently discarded (and Slack would retry, potentially causing event subscription issues). Now downstream modules can subscribe to `SlackcatEvent.MemberJoinedChannel` to react when a user joins a channel — e.g. sending a welcome message, logging membership changes, or triggering onboarding flows.

## Test plan

- [ ] Confirm the project builds cleanly (`./gradlew build`)
- [ ] Invite a user to a channel while the bot is running and verify `MemberJoinedChannel` is emitted in the events flow
- [ ] Confirm no regressions on existing event types (MessageReceived, ReactionAdded, ReactionRemoved, BotMessageReceived)

🤖 Generated with [Claude Code](https://claude.com/claude-code)